### PR TITLE
Feature check webhook credentials

### DIFF
--- a/eventbrite_sboc.module
+++ b/eventbrite_sboc.module
@@ -610,11 +610,11 @@ function _eventbrite_sboc_webhook_callback(){
     $input_json = file_get_contents(EBConsts::EBS_PHP_INPUT_STREAM);
     $input_json_array = json_decode($input_json, TRUE);
 
-    $eb_webhook_user_id_received = !empty($input_json_array['config']['user_id']) ? $input_json_array['config']['user_id'] : '';
+    $eb_webhook_user_id_received = !empty($input_json_array['config']['user_id']) ? $input_json_array['config']['user_id'] : t('EMPTY');
     $webhook_user_id_stored = variable_get(EBConsts::EBS_CONFIG_WEBHOOK_USERT_ID, '');
 
     if (empty($webhook_user_id_stored) || ($eb_webhook_user_id_received != $webhook_user_id_stored)){
-      watchdog(EBConsts::EBS_APPNAME, t('Webhook user id validation test failed. Received: @uid. Check Event Settings page for valid entry.'),
+      watchdog(EBConsts::EBS_APPNAME, t('Webhook user id validation test failed. Received: (@uid). Check Event Settings page for valid entry.'),
         array('@uid' => $eb_webhook_user_id_received), WATCHDOG_ALERT);
       return;
     }

--- a/eventbrite_sboc.module
+++ b/eventbrite_sboc.module
@@ -613,8 +613,8 @@ function _eventbrite_sboc_webhook_callback(){
     $eb_webhook_user_id_received = !empty($input_json_array['config']['user_id']) ? $input_json_array['config']['user_id'] : '';
     $webhook_user_id_stored = variable_get(EBConsts::EBS_CONFIG_WEBHOOK_USERT_ID, '');
 
-    if ($eb_webhook_user_id_received != $webhook_user_id_stored){
-      watchdog(EBConsts::EBS_APPNAME, t('Webhook user id validation test failed. Received: @uid'),
+    if (empty($webhook_user_id_stored) || ($eb_webhook_user_id_received != $webhook_user_id_stored)){
+      watchdog(EBConsts::EBS_APPNAME, t('Webhook user id validation test failed. Received: @uid. Check Event Settings page for valid entry.'),
         array('@uid' => $eb_webhook_user_id_received), WATCHDOG_ALERT);
       return;
     }


### PR DESCRIPTION
1 - Return default non-empty value if received account id is empty ('EMPTY')
2 - Improve validation check